### PR TITLE
Több tagból álló közterületnevek kezelése

### DIFF
--- a/custom_components/fkf-garbage-collection/sensor.py
+++ b/custom_components/fkf-garbage-collection/sensor.py
@@ -139,7 +139,7 @@ class FKFGarbageCollectionSensor(Entity):
         self._hass = hass
         self._name = name
         self._zipcode = zipcode
-        self._publicplace = publicplace.replace(" ","---")
+        self._publicplace = "---".join(publicplace.rsplit(" ", 1))
         self._housenr = housenr
         self._state = None
         self._fkfdata = []


### PR DESCRIPTION
Eltört a kód, ha a 'publicplace' több tagból álló, szóközzel elválasztott közterületnevet tartalmazott (pl. Kossuth Lajos).