### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/fkf-garbage-collection/manifest.json
+++ b/custom_components/fkf-garbage-collection/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://github.com/amaximus/fkf_garbage_collection",
   "dependencies": [],
   "codeowners": ["@amaximus"],
-  "requirements": []
+  "requirements": ["lxml"]
 }


### PR DESCRIPTION
Added lxml pakage to requirements.

Check Home Assistant configuration shows:
Failed config
  General Errors: 
    - Platform error sensor.fkf_garbage_collection - No module named 'lxml'

The component functioning without it, this PR just get rid of the warning message.